### PR TITLE
Add Alexa shift alarm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# My-new-repo
+# Shift Alarm Script
+
+This repository contains a simple Python script `shift_alarm.py` that scans a calendar file for shift start times and schedules alarms on your Alexa device two hours before each shift.
+
+## Requirements
+
+- Python 3
+- `requests` and `ics` packages (install via `pip install requests ics`)
+- An Alexa access token with permission to create reminders (`alexa::alerts:reminders:skill:readwrite` scope)
+- An ICS calendar file containing your work shifts (events should include the word "Shift" in the title by default)
+
+## Usage
+
+```bash
+python shift_alarm.py path/to/calendar.ics <ACCESS_TOKEN> <TIMEZONE>
+```
+
+Example timezone format: `America/New_York`.
+
+You can change the keyword used to detect shift events with `--keyword`.
+
+The script sends a POST request to `https://api.amazonalexa.com/v1/alerts/reminders` for each upcoming shift and sets a reminder two hours before the start time.

--- a/shift_alarm.py
+++ b/shift_alarm.py
@@ -1,0 +1,65 @@
+import argparse
+import json
+import requests
+from ics import Calendar
+from datetime import timedelta
+
+
+def parse_calendar(path):
+    with open(path, 'r') as f:
+        c = Calendar(f.read())
+    return c.events
+
+
+def filter_shift_events(events, keyword="shift"):
+    keyword = keyword.lower()
+    return [e for e in events if e.name and keyword in e.name.lower()]
+
+
+def create_reminder(start_time, token, timezone, message="Upcoming shift"):
+    scheduled_time = (start_time - timedelta(hours=2)).format('YYYY-MM-DDTHH:mm:ss')
+    url = "https://api.amazonalexa.com/v1/alerts/reminders"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json"
+    }
+    body = {
+        "trigger": {
+            "type": "SCHEDULED_ABSOLUTE",
+            "scheduledTime": scheduled_time,
+            "timeZoneId": timezone
+        },
+        "alertInfo": {
+            "spokenInfo": {
+                "content": [{
+                    "locale": "en-US",
+                    "text": message
+                }]
+            }
+        },
+        "pushNotification": {"status": "ENABLED"}
+    }
+    response = requests.post(url, headers=headers, data=json.dumps(body))
+    if response.status_code != 201:
+        print("Failed to set reminder:", response.status_code, response.text)
+    else:
+        print("Reminder set for", scheduled_time)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Set Alexa reminders for shifts")
+    parser.add_argument("ics", help="Path to calendar ICS file")
+    parser.add_argument("token", help="Alexa access token")
+    parser.add_argument("timezone", help="Timezone id, e.g. America/New_York")
+    parser.add_argument("--keyword", default="shift", help="Event name keyword")
+    args = parser.parse_args()
+
+    events = parse_calendar(args.ics)
+    shifts = filter_shift_events(events, args.keyword)
+    for ev in shifts:
+        create_reminder(ev.begin, args.token, args.timezone,
+                        message=f"Shift at {ev.begin.format('YYYY-MM-DD HH:mm')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `shift_alarm.py` to read work shifts from an ICS calendar and create reminders via Alexa API
- update README with usage instructions

## Testing
- `python -m py_compile shift_alarm.py`

------
https://chatgpt.com/codex/tasks/task_e_68512fe71ab88333a0dbcf533e70f824